### PR TITLE
fix: BuildSystemSettings is Editor only

### DIFF
--- a/com.stansassets.build/Editor/Core/BuildSystemSettings.cs
+++ b/com.stansassets.build/Editor/Core/BuildSystemSettings.cs
@@ -7,8 +7,9 @@ namespace StansAssets.Build.Editor
 {
     class BuildSystemSettings : PackageScriptableSettingsSingleton<BuildSystemSettings>, ISerializationCallbackReceiver
     {
+
         public override string PackageName => "com.stansassets.build";
-        protected override bool IsEditorOnly => false;
+        protected override bool IsEditorOnly => true;
 
         public SettingsTab SettingsTab { set; internal get; }
 

--- a/com.stansassets.build/Editor/Core/BuildSystemSettings.cs
+++ b/com.stansassets.build/Editor/Core/BuildSystemSettings.cs
@@ -7,7 +7,6 @@ namespace StansAssets.Build.Editor
 {
     class BuildSystemSettings : PackageScriptableSettingsSingleton<BuildSystemSettings>, ISerializationCallbackReceiver
     {
-
         public override string PackageName => "com.stansassets.build";
         protected override bool IsEditorOnly => true;
 

--- a/com.stansassets.build/Editor/Core/BuildSystemSettings.cs
+++ b/com.stansassets.build/Editor/Core/BuildSystemSettings.cs
@@ -8,9 +8,10 @@ namespace StansAssets.Build.Editor
     class BuildSystemSettings : PackageScriptableSettingsSingleton<BuildSystemSettings>, ISerializationCallbackReceiver
     {
         public override string PackageName => "com.stansassets.build";
+        protected override bool IsEditorOnly => false;
 
         public SettingsTab SettingsTab { set; internal get; }
-            
+
         public string SpreadsheetId => m_SpreadsheetId;
         [SerializeField]
         string m_SpreadsheetId;


### PR DESCRIPTION
## Purpose of this PR
There is no need to have BuildSystemSettings in runtime.

## Testing status
* No tests have been added.
