### PR TITLE
fix: Proper creation of a BuildLocation when it's absent in a project

### DIFF
--- a/com.stansassets.build/Editor/Core/BuildExecutor.cs
+++ b/com.stansassets.build/Editor/Core/BuildExecutor.cs
@@ -22,7 +22,8 @@ namespace StansAssets.Build.Editor
         static BuildExecutor()
         {
             Settings = new BuildSettings();
-          //  RegisterListeners(new BuildContext(BuildExecutorUtility.BuildPlayerOptions, Settings));
+
+            ExecuteRegistrationProcess(new BuildContext(BuildExecutorUtility.BuildPlayerOptions, Settings));
         }
 
         /// <summary>
@@ -51,12 +52,7 @@ namespace StansAssets.Build.Editor
         {
             s_BuildContext = buildContext;
 
-            RegisterListeners(buildContext);
-
-            RegisterUnityPlayerBuildStep();
-            SortTasks();
-            SortSteps();
-
+            ExecuteRegistrationProcess(s_BuildContext);
 
             RunNextStep();
         }
@@ -89,6 +85,15 @@ namespace StansAssets.Build.Editor
             {
                 listener.Register(buildContext);
             }
+        }
+
+        static void ExecuteRegistrationProcess(IBuildContext buildContext)
+        {
+            RegisterListeners(buildContext);
+            RegisterUnityPlayerBuildStep();
+
+            SortTasks();
+            SortSteps();
         }
 
         static void SortSteps()


### PR DESCRIPTION
## Purpose of this PR
Unity showed Build window on each recompile when BuildLocation wasn't set yet or was invalid.

## Testing status
* No tests have been added.

### Manual testing status
Unity Build window doesn't appear now and UnityPlayerBuild step shown in the steps list of package settings, so looks that everything good.

## Comments to reviewers
Default BuildLocation creates correctly, added UnityPlayerBuildStep into registration process when prewarming tool with InitializeOnLoad
