### PR TITLE
feat: replace unity build pipeline option added

### DIFF
--- a/com.stansassets.build/Editor/Core/BuildExecutor.cs
+++ b/com.stansassets.build/Editor/Core/BuildExecutor.cs
@@ -52,9 +52,15 @@ namespace StansAssets.Build.Editor
         {
             s_BuildContext = buildContext;
 
-            ExecuteRegistrationProcess(s_BuildContext);
-
-            RunNextStep();
+            if (BuildSystemSettings.Instance.ReplaceUnityBuildPipeline)
+            {
+                ExecuteRegistrationProcess(s_BuildContext);
+                RunNextStep();
+            }
+            else
+            {
+                BuildPipeline.BuildPlayer(s_BuildContext.BuildPlayerOptions);
+            }
         }
 
         /// <summary>

--- a/com.stansassets.build/Editor/Core/BuildHandler.cs
+++ b/com.stansassets.build/Editor/Core/BuildHandler.cs
@@ -1,10 +1,12 @@
-﻿using UnityEditor;
+﻿using JetBrains.Annotations;
+using UnityEditor;
 
 namespace StansAssets.Build.Editor
 {
+   [UsedImplicitly]
    static class BuildHandler
    {
-      [InitializeOnLoadMethod]
+      [InitializeOnLoadMethod, UsedImplicitly]
       static void Initialize()
       {
          BuildPlayerWindow.RegisterBuildPlayerHandler(RegisterBuildPlayer);

--- a/com.stansassets.build/Editor/Core/BuildSystemSettings.cs
+++ b/com.stansassets.build/Editor/Core/BuildSystemSettings.cs
@@ -22,6 +22,9 @@ namespace StansAssets.Build.Editor
         bool m_AutomatedBuildNumberIncrement;
 
         [SerializeField]
+        bool m_ReplaceUnityBuildPipeline = true;
+
+        [SerializeField]
         List<string> m_MaskList = new List<string>();
 
         public List<ExtraField> ExtraFields => m_ExtraFields;
@@ -33,6 +36,16 @@ namespace StansAssets.Build.Editor
             internal set
             {
                 m_AutomatedBuildNumberIncrement = value;
+                Save();
+            }
+        }
+
+        public bool ReplaceUnityBuildPipeline
+        {
+            get => m_ReplaceUnityBuildPipeline;
+            internal set
+            {
+                m_ReplaceUnityBuildPipeline = value;
                 Save();
             }
         }

--- a/com.stansassets.build/Editor/Window/Tabs/SettingsTab.cs
+++ b/com.stansassets.build/Editor/Window/Tabs/SettingsTab.cs
@@ -43,6 +43,13 @@ namespace StansAssets.Build.Editor
             var refreshBtn = this.Q<Button>("refreshBtn");
             refreshBtn.clicked += UpdateBuildEntitiesCallback;
 
+            var replaceUnityBuildPipelineToggle = this.Q<Toggle>("replaceUnityBuildPipelineToggle");
+            replaceUnityBuildPipelineToggle.value = BuildSystemSettings.Instance.ReplaceUnityBuildPipeline;
+            replaceUnityBuildPipelineToggle.RegisterValueChangedCallback(e =>
+            {
+                BuildSystemSettings.Instance.ReplaceUnityBuildPipeline = e.newValue;
+            });
+
             SetBuildEntities(null, null);
             BindVersionIncrementSection();
         }

--- a/com.stansassets.build/Editor/Window/Tabs/SettingsTab.uss
+++ b/com.stansassets.build/Editor/Window/Tabs/SettingsTab.uss
@@ -74,6 +74,11 @@
     margin-bottom: 5px;
 }
 
+.replace-pipeline-toggle {
+    top: -16px;
+    margin-left: 0;
+}
+
 .list-build-entity {
     padding-bottom: 5px;
 }

--- a/com.stansassets.build/Editor/Window/Tabs/SettingsTab.uxml
+++ b/com.stansassets.build/Editor/Window/Tabs/SettingsTab.uxml
@@ -3,6 +3,7 @@
 
     <sa:SettingsBlock label="Build Pipeline">
         <ui:Button name="refreshBtn" class="btn-refresh-pipelines" tooltip="Refresh Build Steps and Build Tasks"/>
+        <ui:Toggle label="Replace Unity Build Pipeline" name="replaceUnityBuildPipelineToggle" class="replace-pipeline-toggle" />
         <ui:Label text="Build Steps" name="labelBuildStep" class="label-build-entity"/>
         <ui:VisualElement name="listBuildStep" class="list-build-entity"/>
         <ui:Label text="Build Tasks" name="labelBuildTask" class="label-build-entity"/>


### PR DESCRIPTION
## Purpose of this PR
We need the Unity Build Pipeline (when the user press File->Build Settings->Build) replacement to be optional.
Right now we are enforcing the user to use our build pipeline even when making a build. But it doesn't suit everyone.
Added an option that allows leaving the Unity build pipeline to be untouchable.

If _Replace Unity Build Pipeline_ option is enabled, you will get a custom build pipeline whether you making a build via the Unity menu or via your custom code. Otherwise - you will get a custom build pipeline only when you use BuildExecutor.Build deliberately (from your own code).

## Testing status
* No tests have been added.

### Manual testing status
Tested build pipeline in a sample project
