### PR TITLE
feat: 'Incremental build spreadsheet' formated #25

### DIFF
--- a/com.stansassets.build/BuildMetadata/Editor/StansAssets.Build.Meta.Editor.asmdef
+++ b/com.stansassets.build/BuildMetadata/Editor/StansAssets.Build.Meta.Editor.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "StansAssets.Build.Meta.Editor",
+    "rootNamespace": "",
     "references": [
         "StansAssets.Foundation",
         "StansAssets.Build.Meta",
@@ -16,8 +17,12 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
-    "precompiledReferences": [],
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "Google.Apis.Sheets.v4.dll",
+        "Google.Apis.dll",
+        "Google.Apis.Core.dll"
+    ],
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [


### PR DESCRIPTION
## Purpose of this PR
Issue #25 
'Commit Message', 'Build Time' and 'Commit Time' column sizes changed
Commit hyperlink fixed
Date pattern changed to "ddd, dd mmm yyyy (hh:mm)". It's hardcoded. Tell me if enhacement needed
Horizontal alignment:
   first row - CENTER
   'Commit', 'Build Time' and 'Commit Time' - RIGHT
First row BOLD text. Do we need ITALIC here?

## Testing status
No unit tests. If works, result could be checked only manualy

### Manual testing status
Tested with Unity Editor
See the picture
![image](https://user-images.githubusercontent.com/1465544/129025913-b85c7bca-74fa-42c0-8921-7ae2c46f563a.png)


## Comments to reviewers
**NOTICE!** It won't work without this [https://github.com/StansAssets/com.stansassets.google-doc-connector-pro/pull/79](https://github.com/StansAssets/com.stansassets.google-doc-connector-pro/pull/79)
Also look at StansAssets.Build.Meta.Editor.asmdef file. Seems like v0.0.1 is not valid now
